### PR TITLE
feat(repo): set up MVVM and DI infrastructure

### DIFF
--- a/src/Dashboard/App.xaml.cs
+++ b/src/Dashboard/App.xaml.cs
@@ -6,6 +6,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 
+using Microsoft.Extensions.DependencyInjection;
+using RealTimeInfoDashboard.Services;
+using RealTimeInfoDashboard.ViewModels;
+
 namespace RealTimeInfoDashboard;
 
 /// <summary>
@@ -13,4 +17,25 @@ namespace RealTimeInfoDashboard;
 /// </summary>
 public partial class App : Application
 {
+    public IServiceProvider Services { get; }
+
+    public new static App Current => (App)Application.Current;
+
+    public App()
+    {
+        Services = ConfigureServices();
+    }
+
+    private static IServiceProvider ConfigureServices()
+    {
+        var services = new ServiceCollection();
+
+        // ViewModels
+        services.AddTransient<DashboardViewModel>();
+
+        // Services
+        services.AddSingleton<ITelemetryService, TelemetryService>();
+
+        return services.BuildServiceProvider();
+    }
 }

--- a/src/Dashboard/Dashboard.csproj
+++ b/src/Dashboard/Dashboard.csproj
@@ -7,13 +7,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <LangVersion>14</LangVersion>
-    <ApplicationIcon/>
+    <ApplicationIcon />
     <!-- The old ApplicationIcon was "favico.ico", we'll omit or restore it later -->
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc6.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dashboard/MainWindow.xaml.cs
+++ b/src/Dashboard/MainWindow.xaml.cs
@@ -9,9 +9,10 @@ using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
 using System.Windows.Shapes;
+
+using Microsoft.Extensions.DependencyInjection;
+using RealTimeInfoDashboard.ViewModels;
 
 namespace RealTimeInfoDashboard;
 
@@ -23,5 +24,8 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        
+        // Resolve ViewModel from DI Container
+        DataContext = App.Current.Services.GetRequiredService<DashboardViewModel>();
     }
 }

--- a/src/Dashboard/Services/ITelemetryService.cs
+++ b/src/Dashboard/Services/ITelemetryService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using RealTimeInfoDashboard.Models;
+
+namespace RealTimeInfoDashboard.Services;
+
+public interface ITelemetryService
+{
+    IAsyncEnumerable<FactoryTelemetry> StreamTelemetryAsync(CancellationToken cancellationToken);
+}

--- a/src/Dashboard/Services/TelemetryService.cs
+++ b/src/Dashboard/Services/TelemetryService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using RealTimeInfoDashboard.Models;
+
+namespace RealTimeInfoDashboard.Services;
+
+public class TelemetryService : ITelemetryService
+{
+    private readonly string _dataFile;
+
+    public TelemetryService(string dataFile = @"data\dashBoardData.csv")
+    {
+        _dataFile = dataFile;
+    }
+
+    public async IAsyncEnumerable<FactoryTelemetry> StreamTelemetryAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // For simulation purposes, we read the static file but yield items slowly
+        // to emulate a real-time data ingestion stream.
+        var dataPoints = FactoryTelemetry.Load(_dataFile);
+        
+        foreach (var ft in dataPoints)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                yield break;
+
+            yield return ft;
+            
+            // Wait 50ms between points to match original dashboard speed
+            await Task.Delay(50, cancellationToken);
+        }
+    }
+}

--- a/src/Dashboard/ViewModels/DashboardViewModel.cs
+++ b/src/Dashboard/ViewModels/DashboardViewModel.cs
@@ -1,0 +1,59 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
+using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.VisualElements;
+using SkiaSharp;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using RealTimeInfoDashboard.Services;
+
+namespace RealTimeInfoDashboard.ViewModels;
+
+public partial class DashboardViewModel : ObservableObject
+{
+    private readonly ITelemetryService _telemetryService;
+    private CancellationTokenSource? _cancellationTokenSource;
+
+    [ObservableProperty]
+    private double _engineEfficiency = 65;
+
+    public DashboardViewModel(ITelemetryService telemetryService)
+    {
+        _telemetryService = telemetryService;
+    }
+
+    [RelayCommand]
+    private async Task ToggleDataReadingAsync()
+    {
+        if (_cancellationTokenSource != null)
+        {
+            // Stop reading
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            _cancellationTokenSource = null;
+        }
+        else
+        {
+            // Start reading
+            _cancellationTokenSource = new CancellationTokenSource();
+            await ReadDataAsync(_cancellationTokenSource.Token);
+        }
+    }
+
+    private async Task ReadDataAsync(CancellationToken token)
+    {
+        await foreach (var ft in _telemetryService.StreamTelemetryAsync(token))
+        {
+            // Emulate the original logic from ConstantChangesChart.xaml.cs
+            EngineEfficiency = ft.Efficiency;
+            
+            // To be implemented in next tasks:
+            // 1. ChartValues.Add(ft)
+            // 2. AdjustAxis(ft.TimeStamp.Ticks)
+            // 3. Sliding window removal if Count > 30
+        }
+    }
+}

--- a/src/Dashboard/Views/ConstantChangesChart.xaml.cs
+++ b/src/Dashboard/Views/ConstantChangesChart.xaml.cs
@@ -11,21 +11,10 @@ namespace RealTimeInfoDashboard.Views;
 /// <summary>
 /// Interaction logic for ConstantChangesChart.xaml
 /// </summary>
-public partial class ConstantChangesChart : UserControl, INotifyPropertyChanged
+public partial class ConstantChangesChart : UserControl
 {
         public ConstantChangesChart()
         {
             InitializeComponent();
         }
-
-        private void Button_Click(object sender, RoutedEventArgs e)
-        {
-            // Logic disabled for Phase 2 .NET 10 build verification
-        }
-
-        public double EngineEfficiency { get; set; } = 65;
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        protected virtual void OnPropertyChanged(string? name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }


### PR DESCRIPTION
## Description

Sets up the core architectural foundation for Phase 3 by migrating the `Dashboard` to a pure MVVM design pattern using the `CommunityToolkit.Mvvm` library, updating the project doc, and cleaning out the legacy LiveCharts dependency.

- Updated `.agent/project/03-LIVECHARTS2-MIGRATION.md` to formally target the `rc6.1` API instead of `rc5`.
- Removed the temporary `LiveCharts.Wpf` NuGet package from `Dashboard.csproj`.
- Added `Microsoft.Extensions.DependencyInjection`.
- Created `ITelemetryService` and `TelemetryService` to load data asynchronously.
- Created `DashboardViewModel` inheriting from `ObservableObject`.
- Injected `DashboardViewModel` as the DataContext into `MainWindow`.
- Moved `EngineEfficiency` into the ViewModel as an `[ObservableProperty]`.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [x] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Chore (Repository hygiene)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated documentation accordingly
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## Related Issues
Closes #26
