### PR TITLE
Add Continuous Delivery release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    name: Build & Release
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Publish application
+      run: dotnet publish src/Dashboard/Dashboard.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o publish
+
+    - name: Create Zip Archive
+      run: Compress-Archive -Path "publish/*", "data/*" -DestinationPath "RealTimeInfoDashboard-${{ github.ref_name }}-win-x64.zip"
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: "RealTimeInfoDashboard-${{ github.ref_name }}-win-x64.zip"
+        draft: true
+        generate_release_notes: true


### PR DESCRIPTION
## What

Adds the automated Continuous Delivery release workflow for GitHub Actions, satisfying Issue #40.

Closes #40

## Changes

- Created `.github/workflows/release.yml`.
- Configured to trigger when standard release tags (`v*`) are pushed to the repository.
- Uses `dotnet publish` to create a standalone, self-contained `win-x64` executable to `publish/`.
- Compresses the `publish/` and `data/` directories together to guarantee users receive both the executable and the test telemetry `.csv`.
- Uses `softprops/action-gh-release` to generate a GitHub Release draft automatically holding the downloadable application `.zip`.

## Testing

- [x] Targeted tests pass
- [x] Full suite passes
- [x] Build succeeds

## Notes

None.
