### PR TITLE
Add issue/PR templates and SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve the dashboard
+title: 'bug: '
+labels: bug
+assignees: millenniumsingha
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots/Logs**
+If applicable, attach the `crash_task.log` or a screenshot to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows 11]
+ - .NET Version: [e.g. 10.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for the dashboard
+title: 'feat: '
+labels: enhancement
+assignees: millenniumsingha
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or mockups about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What
+_Brief description of the change and why it was needed._
+
+Closes #_ISSUE_ID_
+
+## Changes
+- _Change 1_
+- _Change 2_
+
+## Testing
+- [ ] Targeted tests pass
+- [ ] Full suite passes
+- [ ] Build succeeds
+
+## Notes
+_Any additional context, trade-offs, or follow-up needed._

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+We currently support the following versions of the Real-Time Factory Dashboard with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v2.0.x  | :white_check_mark: |
+| v1.0.x  | :x:                |
+
+## Reporting a Vulnerability
+
+Security issues should be reported here and handled responsibly.
+Because this is an open-source demonstration application without a backend, please direct any vulnerability reports regarding dependencies (or theoretical attack vectors via the CSV parsing engine) to the maintainer via GitHub Issues specifically labeled `security`. Do **not** create public forks illustrating an exploit or zero-day vulnerability without coordinating a triage.
+
+We pledge to review all security-labeled issues within 72 hours.


### PR DESCRIPTION
## What

Adds standard GitHub community health files to standardize repository contributions, satisfying Issue #42.

Closes #42

## Changes

- Created `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` to ensure valid contexts are captured for all new issues.
- Created `.github/pull_request_template.md` to enforce the PR structure used throughout Phase 1-5.
- Created `SECURITY.md` detailing supported versions and the vulnerability reporting process.

## Testing

- [x] Targeted tests pass
- [x] Full suite passes
- [x] Build succeeds

## Notes

None.
