### PR TITLE
fix: pin LiveCharts to rc5.1 and add win-arm64 release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     permissions:
       contents: write
 
+    strategy:
+      matrix:
+        runtime: [win-x64, win-arm64]
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -22,14 +26,14 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Publish application
-      run: dotnet publish src/Dashboard/Dashboard.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o publish
+      run: dotnet publish src/Dashboard/Dashboard.csproj -c Release -r ${{ matrix.runtime }} --self-contained true -p:PublishSingleFile=true -o publish
 
     - name: Create Zip Archive
-      run: Compress-Archive -Path "publish/*" -DestinationPath "RealTimeInfoDashboard-${{ github.ref_name }}-win-x64.zip"
+      run: Compress-Archive -Path "publish/*" -DestinationPath "RealTimeInfoDashboard-${{ github.ref_name }}-${{ matrix.runtime }}.zip"
 
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
-        files: "RealTimeInfoDashboard-${{ github.ref_name }}-win-x64.zip"
+        files: "RealTimeInfoDashboard-${{ github.ref_name }}-${{ matrix.runtime }}.zip"
         draft: true
         generate_release_notes: true

--- a/src/Dashboard/Dashboard.csproj
+++ b/src/Dashboard/Dashboard.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiveChartsCore" Version="2.0.0-rc6.1" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc6.1" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc5.4" />
+    <PackageReference Include="LiveChartsCore" Version="2.0.0-rc5.1" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc5.1" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc5.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
   </ItemGroup>


### PR DESCRIPTION
## What

Hotfix for the v1.0.0 release crash caused by a Dependabot-induced NuGet version mismatch.

## Changes

- **Pin LiveCharts packages to rc5.1**: Dependabot partially bumped `LiveChartsCore` to `rc6.1` while leaving `LiveChartsCore.SkiaSharpView.WPF` on `rc5.4`, creating an API mismatch that caused a `MissingMethodException` at startup.
- **Add ARM64 release target**: The release workflow now builds both `win-x64` and `win-arm64` executables via a GitHub Actions build matrix.

## Testing

- [x] Clean build succeeds locally
- [x] Release workflow validated with matrix strategy

## Notes

Root cause: Dependabot PR merged an incompatible partial version bump of LiveCharts2 packages.
